### PR TITLE
Do not publish a datapoint if nothing was returned from cloudwatch

### DIFF
--- a/base/controller.go
+++ b/base/controller.go
@@ -2,6 +2,11 @@ package base
 
 import (
 	"fmt"
+	"math"
+	"strings"
+	"sync"
+	"time"
+
 	h "github.com/CoverGenius/cloudwatch-prometheus-exporter/helpers"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
@@ -17,13 +22,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/s3"
 	log "github.com/sirupsen/logrus"
-	"strings"
-	"sync"
-	"time"
 )
 
 var (
-	nan     float64 = -1.0
+	nan     float64 = math.NaN()
 	Results         = Metrics{
 		Metric: make(map[string]map[string]*MetricDescription),
 	}

--- a/base/controller.go
+++ b/base/controller.go
@@ -2,7 +2,6 @@ package base
 
 import (
 	"fmt"
-	"math"
 	"strings"
 	"sync"
 	"time"
@@ -25,8 +24,7 @@ import (
 )
 
 var (
-	nan     float64 = math.NaN()
-	Results         = Metrics{
+	Results = Metrics{
 		Metric: make(map[string]map[string]*MetricDescription),
 	}
 )
@@ -289,12 +287,12 @@ func (rd *ResourceDescription) BuildQuery() error {
 func (rd *ResourceDescription) SaveData(c *cloudwatch.GetMetricDataOutput) error {
 	for _, data := range c.MetricDataResults {
 		size := float64(len(data.Values))
-		value := &nan
-		if size > 0 {
-			average, err := h.CountAverage(data.Values, &size)
-			h.LogError(err)
-			value = average
+		if size <= 0 {
+			continue
 		}
+		average, err := h.CountAverage(data.Values, &size)
+		h.LogError(err)
+		value := average
 		result := fmt.Sprintf(
 			"%s{name=\"%s\",id=\"%s\",type=\"%s\",region=\"%s\"} %.2f\n",
 			*data.Id,


### PR DESCRIPTION
Prometheus recommends that missing data should be handled by having missing data, rather than returning a placeholder value such as NaN or -1 

This matches the behavior in the [official exporter](https://github.com/prometheus/cloudwatch_exporter/blob/master/src/main/java/io/prometheus/cloudwatch/CloudWatchCollector.java#L564)
