### PR TITLE
Fix most remaining lint errors

### DIFF
--- a/base/namespaces.go
+++ b/base/namespaces.go
@@ -11,6 +11,7 @@ var namespaces = []string{
 	"AWS/S3",
 }
 
+// GetNamespaces returns a list of AWS namespaces which are configured for this exporter
 func GetNamespaces() []string {
 	return namespaces
 }

--- a/ec2/controller.go
+++ b/ec2/controller.go
@@ -40,6 +40,7 @@ func CreateResourceDescription(nd *b.NamespaceDescription, instance *ec2.Instanc
 	return nil
 }
 
+// CreateResourceList fetches a list of all EC2 instances in the parent region
 func CreateResourceList(nd *b.NamespaceDescription, wg *sync.WaitGroup) error {
 	defer wg.Done()
 	log.Debug("Creating EC2 resource list ...")

--- a/ec2/metrics.go
+++ b/ec2/metrics.go
@@ -186,6 +186,7 @@ var metrics = map[string]*b.MetricDescription{
 	},
 }
 
+// GetMetrics returns a map of MetricDescriptions to be exported for this namespace
 func GetMetrics() map[string]*b.MetricDescription {
 	return metrics
 }

--- a/elasticache/controller.go
+++ b/elasticache/controller.go
@@ -5,10 +5,11 @@ import (
 	h "github.com/CoverGenius/cloudwatch-prometheus-exporter/helpers"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/elasticache"
 	"strings"
 	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticache"
 )
 
 func CreateResourceDescription(nd *b.NamespaceDescription, cc *elasticache.CacheCluster) error {
@@ -33,6 +34,7 @@ func CreateResourceDescription(nd *b.NamespaceDescription, cc *elasticache.Cache
 	return nil
 }
 
+// CreateResourceList fetches a list of all Elasticache clusters in the parent region
 func CreateResourceList(nd *b.NamespaceDescription, wg *sync.WaitGroup) error {
 	defer wg.Done()
 	log.Debug("Creating Elasticache resource list ...")
@@ -51,7 +53,7 @@ func CreateResourceList(nd *b.NamespaceDescription, wg *sync.WaitGroup) error {
 		go func(cc *elasticache.CacheCluster, wg *sync.WaitGroup) {
 			defer wg.Done()
 			resource := strings.Join([]string{"cluster", *cc.CacheClusterId}, ":")
-			arn, err := nd.Parent.BuildArn(&service, &resource)
+			arn, err := nd.Parent.BuildARN(&service, &resource)
 			h.LogError(err)
 			input := elasticache.ListTagsForResourceInput{
 				ResourceName: aws.String(arn),

--- a/elasticache/metrics.go
+++ b/elasticache/metrics.go
@@ -242,6 +242,7 @@ var metrics = map[string]*b.MetricDescription{
 	},
 }
 
+// GetMetrics returns a map of MetricDescriptions to be exported for this namespace
 func GetMetrics() map[string]*b.MetricDescription {
 	return metrics
 }

--- a/elb/metrics.go
+++ b/elb/metrics.go
@@ -130,6 +130,7 @@ var metrics = map[string]*b.MetricDescription{
 	},
 }
 
+// GetMetrics returns a map of MetricDescriptions to be exported for this namespace
 func GetMetrics() map[string]*b.MetricDescription {
 	return metrics
 }

--- a/elbv2/metrics.go
+++ b/elbv2/metrics.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 )
 
-var metrics_alb = map[string]*b.MetricDescription{
+var metricsALB = map[string]*b.MetricDescription{
 	"ActiveConnectionCount": {
 		Help:       aws.String("The total number of concurrent TCP connections active from clients to the load balancer and from the load balancer to targets"),
 		OutputName: aws.String("alb_alive_connection_count"),
@@ -178,7 +178,7 @@ var metrics_alb = map[string]*b.MetricDescription{
 	},
 }
 
-var metrics_nlb = map[string]*b.MetricDescription{
+var metricsNLB = map[string]*b.MetricDescription{
 	"ActiveFlowCount": {
 		Help:       aws.String("The total number of concurrent flows (or connections) from clients to targets. This metric includes connections in the SYN_SENT and ESTABLISHED states. TCP connections are not terminated at the load balancer, so a client opening a TCP connection to a target counts as a single flow"),
 		OutputName: aws.String("nlb_active_flow_count"),
@@ -253,13 +253,14 @@ var metrics_nlb = map[string]*b.MetricDescription{
 	},
 }
 
+// GetMetrics returns a map of MetricDescriptions to be exported for this namespace
 func GetMetrics(t *string) map[string]*b.MetricDescription {
 	switch *t {
 	case "lb-network":
-		return metrics_nlb
+		return metricsNLB
 	case "lb-application":
-		return metrics_alb
+		return metricsALB
 	default:
-		return metrics_alb
+		return metricsALB
 	}
 }

--- a/helpers/file.go
+++ b/helpers/file.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 )
 
+// ReadFile returns the byte contents of a file located at path
+//
+// If an error is encountered while reading the file it is logged NOT returned
 func ReadFile(path *string) *[]byte {
 	absolutePath, err := filepath.Abs(*path)
 	LogError(err)
@@ -14,11 +17,11 @@ func ReadFile(path *string) *[]byte {
 	return &content
 }
 
+// IsFileExists returns true if a file located a path exists
 func IsFileExists(path *string) bool {
 	_, err := os.Stat(*path)
 	if err == nil {
 		return true
-	} else {
-		return false
 	}
+	return false
 }

--- a/helpers/log.go
+++ b/helpers/log.go
@@ -4,6 +4,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// GetLogLevel retuens the logrus log level corresponding to the input integer
+//
+// The number should be between 0 and 5 inclusive.
+// Higher numbers correspond to higher log levels.
 func GetLogLevel(level uint8) log.Level {
 	switch level {
 	case 0:
@@ -23,12 +27,14 @@ func GetLogLevel(level uint8) log.Level {
 	}
 }
 
+// LogError logs err if it is non nil
 func LogError(err error) {
 	if err != nil {
 		log.Error(err)
 	}
 }
 
+// LogErrorExit logs err and exits if the input error is non nil
 func LogErrorExit(err error) {
 	if err != nil {
 		log.Fatal(err)

--- a/helpers/math.go
+++ b/helpers/math.go
@@ -9,7 +9,7 @@ import (
 //
 // If the input slice is empty returns 0
 func Average(items []*float64) (float64, error) {
-	var sum float64 = 0
+	var sum float64
 	for _, item := range items {
 		sum += *item
 	}
@@ -19,7 +19,7 @@ func Average(items []*float64) (float64, error) {
 
 // Sum returns the sum of a slice of float64 pointers
 func Sum(items []*float64) (float64, error) {
-	var sum float64 = 0
+	var sum float64
 	for _, item := range items {
 		sum += *item
 	}
@@ -34,7 +34,7 @@ func Min(items []*float64) (float64, error) {
 		return 0.0, errors.New("Cannot calculate minimum of empty list")
 	}
 
-	var min float64 = *items[0]
+	var min = *items[0]
 	for _, item := range items {
 		if *item < min {
 			min = *item
@@ -45,7 +45,7 @@ func Min(items []*float64) (float64, error) {
 
 // Max returns the largest value from a slice of float64 pointers
 func Max(items []*float64) (float64, error) {
-	var max float64 = 0
+	var max float64
 	for _, item := range items {
 		if *item > max {
 			max = *item

--- a/helpers/string.go
+++ b/helpers/string.go
@@ -1,21 +1,11 @@
 package helpers
 
-import (
-	"strings"
-)
-
-func FormatString(format string, args ...string) string {
-	boilerplate := strings.NewReplacer(args...)
-	out := boilerplate.Replace(format)
-	return out
-}
-
-// StringPointers converts a slice of string values into a slice of string
-// pointers
+// StringPointers converts a slice of string values into a slice of string pointers
+//
 // This function complements aws.StringSlice but works with variadic arguments so that an array literal is not required.
 func StringPointers(strings ...string) []*string {
 	sp := make([]*string, len(strings))
-	for i, _ := range sp {
+	for i := range sp {
 		sp[i] = &strings[i]
 	}
 	return sp

--- a/helpers/yaml.go
+++ b/helpers/yaml.go
@@ -1,16 +1,18 @@
 package helpers
 
 import (
-	"gopkg.in/yaml.v2"
 	"log"
+
+	yaml "gopkg.in/yaml.v2"
 )
 
-func YAMLDecode(f *string, i interface{}) {
-	if IsFileExists(f) {
-		content := ReadFile(f)
+// YAMLDecode reads the file located at path and unmarshals it into the input interface
+func YAMLDecode(path *string, i interface{}) {
+	if IsFileExists(path) {
+		content := ReadFile(path)
 		err := yaml.Unmarshal(*content, i)
 		LogErrorExit(err)
 	} else {
-		log.Fatalf("File: %s does not exists!\n", *f)
+		log.Fatalf("File: %s does not exists!\n", *path)
 	}
 }

--- a/network/controller.go
+++ b/network/controller.go
@@ -1,12 +1,13 @@
 package network
 
 import (
+	"sync"
+
 	b "github.com/CoverGenius/cloudwatch-prometheus-exporter/base"
 	h "github.com/CoverGenius/cloudwatch-prometheus-exporter/helpers"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	log "github.com/sirupsen/logrus"
-	"sync"
 )
 
 func CreateResourceDescription(nd *b.NamespaceDescription, ng *ec2.NatGateway) error {
@@ -30,6 +31,7 @@ func CreateResourceDescription(nd *b.NamespaceDescription, ng *ec2.NatGateway) e
 	return nil
 }
 
+// CreateResourceList fetches a list of all NAT gateways in the region
 func CreateResourceList(nd *b.NamespaceDescription, wg *sync.WaitGroup) error {
 	defer wg.Done()
 	log.Debug("Creating NatGateway resource list ...")

--- a/network/metrics.go
+++ b/network/metrics.go
@@ -122,6 +122,7 @@ var metrics = map[string]*b.MetricDescription{
 	},
 }
 
+// GetMetrics returns a map of MetricDescriptions to be exported for this namespace
 func GetMetrics() map[string]*b.MetricDescription {
 	return metrics
 }

--- a/rds/controller.go
+++ b/rds/controller.go
@@ -33,6 +33,7 @@ func CreateResourceDescription(nd *b.NamespaceDescription, dbi *rds.DBInstance) 
 	return nil
 }
 
+// CreateResourceList fetches a list of all RDS databases in the region
 func CreateResourceList(nd *b.NamespaceDescription, wg *sync.WaitGroup) error {
 	defer wg.Done()
 	log.Debug("Creating RDS resource list ...")

--- a/rds/metrics.go
+++ b/rds/metrics.go
@@ -242,6 +242,7 @@ var metrics = map[string]*b.MetricDescription{
 	},
 }
 
+// GetMetrics returns a map of MetricDescriptions to be exported for this namespace
 func GetMetrics() map[string]*b.MetricDescription {
 	return metrics
 }

--- a/s3/controller.go
+++ b/s3/controller.go
@@ -1,12 +1,13 @@
 package s3
 
 import (
+	"sync"
+
 	b "github.com/CoverGenius/cloudwatch-prometheus-exporter/base"
 	h "github.com/CoverGenius/cloudwatch-prometheus-exporter/helpers"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	log "github.com/sirupsen/logrus"
-	"sync"
 )
 
 func CreateResourceDescription(nd *b.NamespaceDescription, bucket *s3.Bucket) error {
@@ -35,7 +36,9 @@ func CreateResourceDescription(nd *b.NamespaceDescription, bucket *s3.Bucket) er
 	return nil
 }
 
-// channel can be added instead of sync.WaitGroup
+// CreateResourceList fetches a list of all S3 buckets in the region
+//
+// TODO channel can be added instead of sync.WaitGroup
 func CreateResourceList(nd *b.NamespaceDescription, wg *sync.WaitGroup) error {
 	log.Debug("Creating S3 resource list ...")
 	defer wg.Done()
@@ -65,12 +68,12 @@ func CreateResourceList(nd *b.NamespaceDescription, wg *sync.WaitGroup) error {
 				return
 			}
 
-			location_input := s3.GetBucketTaggingInput{
+			locationInput := s3.GetBucketTaggingInput{
 				Bucket: bucket.Name,
 			}
 
-			tags, err := session.GetBucketTagging(&location_input)
-			if b.SameErrorType(err, &tagError) == false {
+			tags, err := session.GetBucketTagging(&locationInput)
+			if b.IsSameErrorType(err, &tagError) == false {
 				h.LogError(err)
 			}
 

--- a/s3/metrics.go
+++ b/s3/metrics.go
@@ -36,6 +36,7 @@ var metrics = map[string]*b.MetricDescription{
 	},
 }
 
+// GetMetrics returns a map of MetricDescriptions to be exported for this namespace
 func GetMetrics() map[string]*b.MetricDescription {
 	return metrics
 }


### PR DESCRIPTION
In general most fixes are of the form:
- Change method/function to be private if they aren't used outside the package namespace
- Change identifier names use idomatic go naming conventions
- Add docstrings to exported functions/methods