### PR TITLE
Add a go report card badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # cloudwatch-prometheus-exporter
-Multi regional cloudwatch prometheus exporter
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/CoverGenius/cloudwatch-prometheus-exporter)][goreportcard]
+
+Cloudwatch prometheus exporter with support for multiple regions and counter metrics
 
 ./cloudwatch-prometheus-exporter -config </path/to/your/config.yaml>
+
+## Configuration
 
 Example of config file:
 ```


### PR DESCRIPTION
A go report card badege is a good way to show the general quality of a
go library or binary and highlight any issues that may come up.