### PR TITLE
Don't wait poll interval to perform the first scrape

### DIFF
--- a/base/config.go
+++ b/base/config.go
@@ -1,0 +1,20 @@
+package base
+
+// Config represents the exporter configuration passed which is read at runtime from a YAML file.
+type Config struct {
+	Listen       string            `yaml:"listen,omitempty"`        // TCP Dial address for Prometheus HTTP API to listen on
+	APIKey       string            `yaml:"api_key"`                 // AWS API Key ID
+	APISecret    string            `yaml:"api_secret"`              // AWS API Secret
+	Tags         []*TagDescription `yaml:"tags,omitempty"`          // Tags to filter resources by
+	Period       uint8             `yaml:"period,omitempty"`        // How far back to request data for in minutes.
+	Regions      []*string         `yaml:"regions"`                 // Which AWS regions to query resources and metrics for
+	PollInterval uint8             `yaml:"poll_interval,omitempty"` // How often to fetch new data from the Cloudwatch API.
+	LogLevel     uint8             `yaml:"log_level,omitempty"`     // Logging verbosity level
+	Metrics      metric            `yaml:"metrics,omitempty"`       // Map of per metric configuration overrides
+}
+
+type metric struct {
+	Data map[string]struct {
+		Period int `yaml:"length,omitempty"` // How far back to request data for in minutes.
+	} `yaml:",omitempty,inline"`
+}

--- a/build/cloudwatch-prometheus-exporter.spec
+++ b/build/cloudwatch-prometheus-exporter.spec
@@ -5,7 +5,7 @@
 
 
 Name: cloudwatch-prometheus-exporter
-Version: 0.0.9
+Version: 0.0.10
 Release: 0%{?dist}
 Summary: Cloudwatch Prometheus Exporter
 License: BSD
@@ -38,6 +38,8 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Mon Apr 06 2020 Andrew Wright <andrew.w@covergenius.com>
+- Don't wait poll interval for the first scrape
 * Tue Mar 31 2020 Andrew Wright <andrew.w@covergenius.com>
 - Automatically determine the metric type based on the metric aggregation used
 * Mon Mar 30 2020 Andrew Wright <andrew.w@covergenius.com>


### PR DESCRIPTION
When the exporter first starts up it currently waits for one poll interval before fetching the first set of data. This means that during a restart of the exporter in production it may be possible to lose one poll interval of data. The initial delay also makes local testing slower than necessary. 

Also makes a couple of minor refactors in preparation for upcoming config changes:
* Move config type to a separate file
* Add wrapper type for interacting with cloudwatch labels