### PR TITLE
Fix race condition when fetching resources

### DIFF
--- a/base/config.go
+++ b/base/config.go
@@ -53,6 +53,7 @@ func (c *Config) ConstructMetrics(defaults map[string]map[string]*MetricDescript
 						PeriodSeconds: defaultMetric.PeriodSeconds,
 						RangeSeconds:  defaultMetric.RangeSeconds,
 						Dimensions:    defaultMetric.Dimensions,
+						Statistics:    defaultMetric.Statistic,
 					})
 				}
 			}

--- a/base/config.go
+++ b/base/config.go
@@ -13,8 +13,8 @@ type configMetric struct {
 	Dimensions    []*cloudwatch.Dimension `yaml:"dimensions"`     // The resource dimensions to generate individual series for (via labels)
 	Statistics    []*string               `yaml:"statistics"`     // List of AWS statistics to use.
 	OutputName    string                  `yaml:"output_name"`    // Allows override of the generate metric name
-	RangeSeconds  int64                   `yaml:"range_seconds"`  // How far back to request data for in seconds.
 	PeriodSeconds int64                   `yaml:"period_seconds"` // Granularity of results from cloudwatch API.
+	RangeSeconds  int64                   `yaml:"range_seconds"`  // How far back to request data for in seconds.
 }
 
 type metric struct {
@@ -43,8 +43,7 @@ type Config struct {
 func (c *Config) ConstructMetrics(defaults map[string]map[string]*MetricDescription) map[string][]*MetricDescription {
 	mds := make(map[string][]*MetricDescription)
 	for namespace, metrics := range c.Metrics.Data {
-
-		if len(metrics) <= 0 {
+		if len(metrics) == 0 {
 			if namespaceDefaults, ok := defaults[namespace]; ok {
 				for key, defaultMetric := range namespaceDefaults {
 					metrics = append(metrics, &configMetric{

--- a/base/prometheus.go
+++ b/base/prometheus.go
@@ -132,5 +132,4 @@ func NewBatchCounterVec(opts prometheus.Opts, labels []string) *BatchCounterVec 
 			labels,
 		),
 	}
-
 }

--- a/build/cloudwatch-prometheus-exporter.spec
+++ b/build/cloudwatch-prometheus-exporter.spec
@@ -5,7 +5,7 @@
 
 
 Name: cloudwatch-prometheus-exporter
-Version: 0.1.0
+Version: 0.1.1
 Release: 0%{?dist}
 Summary: Cloudwatch Prometheus Exporter
 License: BSD
@@ -38,6 +38,8 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Thu Apr 16 2020 Andrew Wright <andrew.w@covergenius.com>
+- Fix race condition when fetching resource list
 * Wed Apr 15 2020 Andrew Wright <andrew.w@covergenius.com>
 - Allow runtime configuration of metrics
 * Wed Apr 08 2020 Andrew Wright <andrew.w@covergenius.com>

--- a/elasticache/controller.go
+++ b/elasticache/controller.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elasticache"
 )
 
-func CreateResourceDescription(nd *b.NamespaceDescription, cc *elasticache.CacheCluster) (*b.ResourceDescription, error) {
+func createResourceDescription(nd *b.NamespaceDescription, cc *elasticache.CacheCluster) (*b.ResourceDescription, error) {
 	rd := b.ResourceDescription{}
 	dd := []*b.DimensionDescription{
 		{
@@ -21,7 +21,7 @@ func CreateResourceDescription(nd *b.NamespaceDescription, cc *elasticache.Cache
 		},
 	}
 	err := rd.BuildDimensions(dd)
-	h.LogError(err)
+	h.LogIfError(err)
 	rd.ID = cc.CacheClusterId
 	rd.Name = cc.CacheClusterId
 	rd.Type = aws.String("elasticache")
@@ -31,48 +31,49 @@ func CreateResourceDescription(nd *b.NamespaceDescription, cc *elasticache.Cache
 }
 
 // CreateResourceList fetches a list of all Elasticache clusters in the parent region
-func CreateResourceList(nd *b.NamespaceDescription, wg *sync.WaitGroup) error {
+func CreateResourceList(nd *b.NamespaceDescription, wg *sync.WaitGroup) {
 	defer wg.Done()
 	log.Debug("Creating Elasticache resource list ...")
 
-	resources := []*b.ResourceDescription{}
 	session := elasticache.New(nd.Parent.Session)
 	input := elasticache.DescribeCacheClustersInput{}
 	result, err := session.DescribeCacheClusters(&input)
-	h.LogError(err)
+	h.LogIfError(err)
 	service := "elasticache"
 
 	var w sync.WaitGroup
 	w.Add(len(result.CacheClusters))
-	ch := make(chan (*b.ResourceDescription), len(result.CacheClusters))
+	ch := make(chan *b.ResourceDescription, len(result.CacheClusters))
 	for _, cc := range result.CacheClusters {
 		go func(cc *elasticache.CacheCluster, wg *sync.WaitGroup) {
 			defer wg.Done()
+
 			resource := strings.Join([]string{"cluster", *cc.CacheClusterId}, ":")
 			arn, err := nd.Parent.BuildARN(&service, &resource)
-			h.LogError(err)
+			h.LogIfError(err)
+
 			input := elasticache.ListTagsForResourceInput{
 				ResourceName: aws.String(arn),
 			}
 			tags, err := session.ListTagsForResource(&input)
-			h.LogError(err)
+			h.LogIfError(err)
 
 			if nd.Parent.TagsFound(tags) {
-				if r, err := CreateResourceDescription(nd, cc); err == nil {
+				if r, err := createResourceDescription(nd, cc); err == nil {
 					ch <- r
 				}
-				h.LogError(err)
+				h.LogIfError(err)
 			}
 		}(cc, &w)
 	}
 	w.Wait()
 	close(ch)
+
+	resources := []*b.ResourceDescription{}
 	for r := range ch {
 		resources = append(resources, r)
 	}
-
 	nd.Mutex.Lock()
 	nd.Resources = resources
 	nd.Mutex.Unlock()
-	return nil
 }

--- a/helpers/file.go
+++ b/helpers/file.go
@@ -11,17 +11,14 @@ import (
 // If an error is encountered while reading the file it is logged NOT returned
 func ReadFile(path *string) *[]byte {
 	absolutePath, err := filepath.Abs(*path)
-	LogError(err)
+	LogIfError(err)
 	content, err := ioutil.ReadFile(absolutePath)
-	LogError(err)
+	LogIfError(err)
 	return &content
 }
 
 // IsFileExists returns true if a file located a path exists
 func IsFileExists(path *string) bool {
 	_, err := os.Stat(*path)
-	if err == nil {
-		return true
-	}
-	return false
+	return err == nil
 }

--- a/helpers/log.go
+++ b/helpers/log.go
@@ -27,15 +27,15 @@ func GetLogLevel(level uint8) log.Level {
 	}
 }
 
-// LogError logs err if it is non nil
-func LogError(err error) {
+// LogIfError logs err if it is non nil
+func LogIfError(err error) {
 	if err != nil {
 		log.Error(err)
 	}
 }
 
-// LogErrorExit logs err and exits if the input error is non nil
-func LogErrorExit(err error) {
+// LogIfErrorExit logs err and exits if the input error is non nil
+func LogIfErrorExit(err error) {
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/helpers/math.go
+++ b/helpers/math.go
@@ -31,7 +31,7 @@ func Sum(items []*float64) (float64, error) {
 // returns an error if the input slice is empty
 func Min(items []*float64) (float64, error) {
 	if len(items) < 1 {
-		return 0.0, errors.New("Cannot calculate minimum of empty list")
+		return 0.0, errors.New("cannot calculate minimum of empty list")
 	}
 
 	var min = *items[0]

--- a/helpers/string.go
+++ b/helpers/string.go
@@ -10,10 +10,10 @@ import (
 // StringPointers converts a slice of string values into a slice of string pointers
 //
 // This function complements aws.StringSlice but works with variadic arguments so that an array literal is not required.
-func StringPointers(strings ...string) []*string {
-	sp := make([]*string, len(strings))
+func StringPointers(s ...string) []*string {
+	sp := make([]*string, len(s))
 	for i := range sp {
-		sp[i] = &strings[i]
+		sp[i] = &s[i]
 	}
 	return sp
 }

--- a/helpers/yaml.go
+++ b/helpers/yaml.go
@@ -11,7 +11,7 @@ func YAMLDecode(path *string, i interface{}) {
 	if IsFileExists(path) {
 		content := ReadFile(path)
 		err := yaml.Unmarshal(*content, i)
-		LogErrorExit(err)
+		LogIfErrorExit(err)
 	} else {
 		log.Fatalf("File: %s does not exists!\n", *path)
 	}

--- a/rds/controller.go
+++ b/rds/controller.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 )
 
-func CreateResourceDescription(nd *b.NamespaceDescription, dbi *rds.DBInstance) error {
+func createResourceDescription(nd *b.NamespaceDescription, dbi *rds.DBInstance) (*b.ResourceDescription, error) {
 	rd := b.ResourceDescription{}
 	dd := []*b.DimensionDescription{
 		{
@@ -19,31 +19,30 @@ func CreateResourceDescription(nd *b.NamespaceDescription, dbi *rds.DBInstance) 
 			Value: dbi.DBInstanceIdentifier,
 		},
 	}
-	err := rd.BuildDimensions(dd)
-	h.LogError(err)
+	if err := rd.BuildDimensions(dd); err != nil {
+		return nil, err
+	}
+
 	rd.ID = dbi.DBInstanceIdentifier
 	rd.Name = dbi.DBInstanceIdentifier
 	rd.Type = aws.String("rds")
 	rd.Parent = nd
-	nd.Mutex.Lock()
-	nd.Resources = append(nd.Resources, &rd)
-	nd.Mutex.Unlock()
 
-	return nil
+	return &rd, nil
 }
 
 // CreateResourceList fetches a list of all RDS databases in the region
-func CreateResourceList(nd *b.NamespaceDescription, wg *sync.WaitGroup) error {
+func CreateResourceList(nd *b.NamespaceDescription, wg *sync.WaitGroup) {
 	defer wg.Done()
 	log.Debug("Creating RDS resource list ...")
-	nd.Resources = []*b.ResourceDescription{}
 	session := rds.New(nd.Parent.Session)
 	input := rds.DescribeDBInstancesInput{}
 	result, err := session.DescribeDBInstances(&input)
-	h.LogError(err)
+	h.LogIfError(err)
 
 	var w sync.WaitGroup
 	w.Add(len(result.DBInstances))
+	ch := make(chan *b.ResourceDescription, len(result.DBInstances))
 	for _, dbi := range result.DBInstances {
 		go func(dbi *rds.DBInstance, wg *sync.WaitGroup) {
 			defer wg.Done()
@@ -51,14 +50,24 @@ func CreateResourceList(nd *b.NamespaceDescription, wg *sync.WaitGroup) error {
 				ResourceName: dbi.DBInstanceArn,
 			}
 			tags, err := session.ListTagsForResource(&input)
-			h.LogError(err)
+			h.LogIfError(err)
 
 			if nd.Parent.TagsFound(tags) {
-				err := CreateResourceDescription(nd, dbi)
-				h.LogError(err)
+				if r, err := createResourceDescription(nd, dbi); err == nil {
+					ch <- r
+				}
+				h.LogIfError(err)
 			}
 		}(dbi, &w)
 	}
 	w.Wait()
-	return nil
+	close(ch)
+
+	resources := []*b.ResourceDescription{}
+	for r := range ch {
+		resources = append(resources, r)
+	}
+	nd.Mutex.Lock()
+	nd.Resources = resources
+	nd.Mutex.Unlock()
 }


### PR DESCRIPTION
Currently when fetching resources an empty array for the current list of resources is initialized and is saved in place of the existing list. If this list is accessed by one of the metrics go routines before it has been fully populated then that metric will not be populated for the missing resources.

This diff adds locking and changes the new array to only be saved once fully populated to prevent such data races from occurring.